### PR TITLE
added inverse pipeline

### DIFF
--- a/carla/models/catalog/catalog.py
+++ b/carla/models/catalog/catalog.py
@@ -8,7 +8,7 @@ import torch
 from carla.data.catalog import DataCatalog
 from carla.data.load_catalog import load_catalog
 from carla.models.api import MLModel
-from carla.models.pipelining import encode, order_data, scale
+from carla.models.pipelining import decode, descale, encode, order_data, scale
 
 from .load_model import load_model
 
@@ -100,12 +100,19 @@ class MLModelCatalog(MLModel):
         # Preparing pipeline components
         self._use_pipeline = use_pipeline
         self._pipeline = self.__init_pipeline()
+        self._inverse_pipeline = self.__init_inverse_pipeline()
 
     def __init_pipeline(self) -> List[Tuple[str, Callable]]:
         return [
             ("scaler", lambda x: scale(self.scaler, self._continuous, x)),
             ("encoder", lambda x: encode(self.encoder, self._categoricals, x)),
             ("order", lambda x: order_data(self._feature_input_order, x)),
+        ]
+
+    def __init_inverse_pipeline(self) -> List[Tuple[str, Callable]]:
+        return [
+            ("encoder", lambda x: decode(self.encoder, self._categoricals, x)),
+            ("scaler", lambda x: descale(self.scaler, self._continuous, x)),
         ]
 
     def get_pipeline_element(self, key: str) -> Callable:
@@ -136,6 +143,18 @@ class MLModelCatalog(MLModel):
         """
         return self._pipeline
 
+    @property
+    def inverse_pipeline(self) -> List[Tuple[str, Callable]]:
+        """
+        Returns transformations steps for output after predictions.
+
+        Returns
+        -------
+        pipeline : list
+            List of (name, transform) tuples that are chained in the order in which they are preformed.
+        """
+        return self._inverse_pipeline
+
     def perform_pipeline(self, df: pd.DataFrame) -> pd.DataFrame:
         """
         Transforms input for prediction into correct form.
@@ -157,6 +176,29 @@ class MLModelCatalog(MLModel):
         output = df.copy()
 
         for trans_name, trans_function in self._pipeline:
+            output = trans_function(output)
+
+        return output
+
+    def perform_inverse_pipeline(self, df: pd.DataFrame) -> pd.DataFrame:
+        """
+        Transforms output after prediction back into original form.
+        Only possible for DataFrames with preprocessing steps.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            Contains normalized and encoded data.
+
+        Returns
+        -------
+        output : pd.DataFrame
+            Prediction output denormalized and decoded
+
+        """
+        output = df.copy()
+
+        for trans_name, trans_function in self._inverse_pipeline:
             output = trans_function(output)
 
         return output

--- a/carla/models/pipelining/__init__.py
+++ b/carla/models/pipelining/__init__.py
@@ -1,3 +1,3 @@
 # flake8: noqa
 
-from .steps import decode, encode, order_data, scale
+from .steps import decode, descale, encode, order_data, scale

--- a/carla/models/pipelining/steps.py
+++ b/carla/models/pipelining/steps.py
@@ -31,6 +31,33 @@ def scale(
     return output
 
 
+def descale(
+    fitted_scaler: BaseEstimator, features: List[str], df: pd.DataFrame
+) -> pd.DataFrame:
+    """
+    Pipeline function to de-normalize data with fitted sklearn scaler.
+
+    Parameters
+    ----------
+    fitted_scaler : sklearn Scaler
+        Normalizes input data
+    features : list
+        List of continuous feature
+    df : pd.DataFrame
+        Data we want to de-normalize
+
+    Returns
+    -------
+    output : pd.DataFrame
+        Whole DataFrame with de-normalized values
+
+    """
+    output = df.copy()
+    output[features] = fitted_scaler.inverse_transform(output[features])
+
+    return output
+
+
 def encode(
     fitted_encoder: BaseEstimator, features: List[str], df: pd.DataFrame
 ) -> pd.DataFrame:
@@ -96,6 +123,8 @@ def decode(
 def order_data(feature_order: List[str], df: pd.DataFrame) -> pd.DataFrame:
     """
     Restores the correct input feature order for the ML model
+
+    Only works for encoded data
 
     Parameters
     ----------

--- a/test/test_mlmodel.py
+++ b/test/test_mlmodel.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 import torch
+from pandas._testing import assert_frame_equal
 
 from carla.data.catalog import DataCatalog
 from carla.models.catalog import MLModelCatalog
@@ -50,13 +51,7 @@ def test_inverse_pipeline():
     expected_data[data.continous] = expected_data[data.continous].astype("float")
     expected_data.columns = detransformed_data.columns
 
-    # sklearn scales produces results of e.g. 38.9999999999 vs 39.0
-    assert (
-        expected_data[data.continous] - detransformed_data[data.continous]
-    ).sum().sum() == pytest.approx(0.0, abs=1e-6)
-    assert detransformed_data[data.categoricals].equals(
-        expected_data[data.categoricals]
-    )
+    assert_frame_equal(expected_data, detransformed_data)
 
 
 @pytest.mark.parametrize("model_type", testmodel)

--- a/test/test_mlmodel.py
+++ b/test/test_mlmodel.py
@@ -45,13 +45,18 @@ def test_inverse_pipeline():
 
     transformed_data = model_tf_adult.perform_pipeline(data.raw)
     detransformed_data = model_tf_adult.perform_inverse_pipeline(transformed_data)
-    # sklearn scales produces results of e.g. 38.9999999999 vs 39.0
-    detransformed_data[data.continous] = detransformed_data[data.continous].round(1)
 
     expected_data = data.raw[detransformed_data.columns]
     expected_data[data.continous] = expected_data[data.continous].astype("float")
     expected_data.columns = detransformed_data.columns
-    assert detransformed_data.equals(expected_data)
+
+    # sklearn scales produces results of e.g. 38.9999999999 vs 39.0
+    assert (
+        expected_data[data.continous] - detransformed_data[data.continous]
+    ).sum().sum() == pytest.approx(0.0, abs=1e-6)
+    assert detransformed_data[data.categoricals].equals(
+        expected_data[data.categoricals]
+    )
 
 
 @pytest.mark.parametrize("model_type", testmodel)

--- a/test/test_mlmodel.py
+++ b/test/test_mlmodel.py
@@ -37,6 +37,23 @@ def test_properties():
     assert model_tf_adult.feature_input_order == exp_feature_order_adult
 
 
+def test_inverse_pipeline():
+    data_name = "adult"
+    data = DataCatalog(data_name)
+
+    model_tf_adult = MLModelCatalog(data, "ann")
+
+    transformed_data = model_tf_adult.perform_pipeline(data.raw)
+    detransformed_data = model_tf_adult.perform_inverse_pipeline(transformed_data)
+    # sklearn scales produces results of e.g. 38.9999999999 vs 39.0
+    detransformed_data[data.continous] = detransformed_data[data.continous].round(1)
+
+    expected_data = data.raw[detransformed_data.columns]
+    expected_data[data.continous] = expected_data[data.continous].astype("float")
+    expected_data.columns = detransformed_data.columns
+    assert detransformed_data.equals(expected_data)
+
+
 @pytest.mark.parametrize("model_type", testmodel)
 @pytest.mark.parametrize("data_name", test_data)
 def test_predictions_tf(model_type, data_name):


### PR DESCRIPTION
Adding the inverse pipeline, i.e. reverting the changes the "forward" pipeline makes. 
Specifically this allows the user to de-normalize the data, according to the values of the original data, and change one-hot encoded categorical features back to their String values. 
Note that this also works for new data, e.g. counterfactuals, as the one hot encoding does not change, and we can use the features of the original data to de-normalize the counterfactuals.