### PR TITLE
Fix counterfactual ordering

### DIFF
--- a/carla/recourse_methods/catalog/actionable_recourse/model.py
+++ b/carla/recourse_methods/catalog/actionable_recourse/model.py
@@ -253,6 +253,6 @@ class ActionableRecourse(RecourseMethod):
         df_cfs[self._mlmodel.data.target] = np.argmax(
             self._mlmodel.predict_proba(cfs), axis=1
         )
-        df_cfs = check_counterfactuals(self._mlmodel, df_cfs)
+        df_cfs = check_counterfactuals(self._mlmodel, df_cfs, factuals.index)
         df_cfs = self._mlmodel.get_ordered_features(df_cfs)
         return df_cfs

--- a/carla/recourse_methods/catalog/cchvae/model.py
+++ b/carla/recourse_methods/catalog/cchvae/model.py
@@ -250,6 +250,6 @@ class CCHVAE(RecourseMethod):
             axis=1,
         )
 
-        df_cfs = check_counterfactuals(self._mlmodel, df_cfs)
+        df_cfs = check_counterfactuals(self._mlmodel, df_cfs, factuals.index)
         df_cfs = self._mlmodel.get_ordered_features(df_cfs)
         return df_cfs

--- a/carla/recourse_methods/catalog/cem/model.py
+++ b/carla/recourse_methods/catalog/cem/model.py
@@ -547,6 +547,6 @@ class CEM(RecourseMethod):
         df_cfs = factuals.apply(
             lambda x: self._counterfactual_search(x), axis=1, raw=True
         )
-        df_cfs = check_counterfactuals(self._mlmodel, df_cfs)
+        df_cfs = check_counterfactuals(self._mlmodel, df_cfs, factuals.index)
         df_cfs = self._mlmodel.get_ordered_features(df_cfs)
         return df_cfs

--- a/carla/recourse_methods/catalog/clue/model.py
+++ b/carla/recourse_methods/catalog/clue/model.py
@@ -187,6 +187,6 @@ class Clue(RecourseMethod):
             list_cfs.append(counterfactual)
 
         # Convert output into correct format
-        df_cfs = check_counterfactuals(self._mlmodel, list_cfs)
+        df_cfs = check_counterfactuals(self._mlmodel, list_cfs, factuals.index)
         df_cfs = self._mlmodel.get_ordered_features(df_cfs)
         return df_cfs

--- a/carla/recourse_methods/catalog/crud/model.py
+++ b/carla/recourse_methods/catalog/crud/model.py
@@ -155,7 +155,9 @@ class CRUD(RecourseMethod):
         )
 
         cf_df = check_counterfactuals(
-            self._mlmodel, df_cfs.drop(self._mlmodel.data.target, axis=1)
+            self._mlmodel,
+            df_cfs.drop(self._mlmodel.data.target, axis=1),
+            factuals.index,
         )
         cf_df = self._mlmodel.get_ordered_features(cf_df)
         return cf_df

--- a/carla/recourse_methods/catalog/dice/model.py
+++ b/carla/recourse_methods/catalog/dice/model.py
@@ -92,6 +92,6 @@ class Dice(RecourseMethod):
 
         list_cfs = dice_exp.cf_examples_list
         df_cfs = pd.concat([cf.final_cfs_df for cf in list_cfs], ignore_index=True)
-        df_cfs = check_counterfactuals(self._mlmodel, df_cfs)
+        df_cfs = check_counterfactuals(self._mlmodel, df_cfs, factuals.index)
         df_cfs = self._mlmodel.get_ordered_features(df_cfs)
         return df_cfs

--- a/carla/recourse_methods/catalog/face/model.py
+++ b/carla/recourse_methods/catalog/face/model.py
@@ -117,6 +117,6 @@ class Face(RecourseMethod):
             )
             list_cfs.append(cf)
 
-        df_cfs = check_counterfactuals(self._mlmodel, list_cfs)
+        df_cfs = check_counterfactuals(self._mlmodel, list_cfs, factuals.index)
         df_cfs = self._mlmodel.get_ordered_features(df_cfs)
         return df_cfs

--- a/carla/recourse_methods/catalog/feature_tweak/model.py
+++ b/carla/recourse_methods/catalog/feature_tweak/model.py
@@ -369,6 +369,8 @@ class FeatureTweak(RecourseMethod):
             )
             counterfactuals.append(counterfactual)
 
-        counterfactuals_df = check_counterfactuals(self._mlmodel, counterfactuals)
+        counterfactuals_df = check_counterfactuals(
+            self._mlmodel, counterfactuals, factuals.index
+        )
         counterfactuals_df = self._mlmodel.get_ordered_features(counterfactuals_df)
         return counterfactuals_df

--- a/carla/recourse_methods/catalog/focus/model.py
+++ b/carla/recourse_methods/catalog/focus/model.py
@@ -226,7 +226,7 @@ class FOCUS(RecourseMethod):
             best_perturb = sess.run(pf)
 
         df_cfs = pd.DataFrame(best_perturb, columns=self.model.data.continuous)
-        df_cfs = check_counterfactuals(self._mlmodel, df_cfs)
+        df_cfs = check_counterfactuals(self._mlmodel, df_cfs, factuals.index)
         df_cfs = self._mlmodel.get_ordered_features(df_cfs)
         return df_cfs
 

--- a/carla/recourse_methods/catalog/growing_spheres/model.py
+++ b/carla/recourse_methods/catalog/growing_spheres/model.py
@@ -70,6 +70,6 @@ class GrowingSpheres(RecourseMethod):
             )
             list_cfs.append(counterfactual)
 
-        df_cfs = check_counterfactuals(self._mlmodel, list_cfs)
+        df_cfs = check_counterfactuals(self._mlmodel, list_cfs, factuals.index)
         df_cfs = self._mlmodel.get_ordered_features(df_cfs)
         return df_cfs

--- a/carla/recourse_methods/catalog/revise/model.py
+++ b/carla/recourse_methods/catalog/revise/model.py
@@ -151,7 +151,7 @@ class Revise(RecourseMethod):
             cat_features_indices, device, factuals
         )
 
-        cf_df = check_counterfactuals(self._mlmodel, list_cfs)
+        cf_df = check_counterfactuals(self._mlmodel, list_cfs, factuals.index)
         cf_df = self._mlmodel.get_ordered_features(cf_df)
         return cf_df
 

--- a/carla/recourse_methods/catalog/wachter/model.py
+++ b/carla/recourse_methods/catalog/wachter/model.py
@@ -114,6 +114,6 @@ class Wachter(RecourseMethod):
             axis=1,
         )
 
-        df_cfs = check_counterfactuals(self._mlmodel, df_cfs)
+        df_cfs = check_counterfactuals(self._mlmodel, df_cfs, factuals.index)
         df_cfs = self._mlmodel.get_ordered_features(df_cfs)
         return df_cfs

--- a/carla/recourse_methods/processing/counterfactuals.py
+++ b/carla/recourse_methods/processing/counterfactuals.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Union
 import numpy as np
 import pandas as pd
 import torch
+from pandas import Index
 
 from carla.models.api import MLModel
 
@@ -10,6 +11,7 @@ from carla.models.api import MLModel
 def check_counterfactuals(
     mlmodel: MLModel,
     counterfactuals: Union[List, pd.DataFrame],
+    factuals_index: Index,
     negative_label: int = 0,
 ) -> pd.DataFrame:
     """
@@ -21,6 +23,7 @@ def check_counterfactuals(
     ----------
     mlmodel: Black-box-model we want to discover
     counterfactuals: List or DataFrame of generated samples from recourse method
+    factuals_index: Index of the original factuals DataFrame
     negative_label: Defines the negative label.
 
     Returns
@@ -29,7 +32,9 @@ def check_counterfactuals(
     """
     if isinstance(counterfactuals, list):
         df_cfs = pd.DataFrame(
-            np.array(counterfactuals), columns=mlmodel.feature_input_order
+            np.array(counterfactuals),
+            columns=mlmodel.feature_input_order,
+            index=factuals_index.copy(),
         )
     else:
         df_cfs = counterfactuals.copy()

--- a/carla/recourse_methods/processing/counterfactuals.py
+++ b/carla/recourse_methods/processing/counterfactuals.py
@@ -3,7 +3,6 @@ from typing import Dict, List, Union
 import numpy as np
 import pandas as pd
 import torch
-from pandas import Index
 
 from carla.models.api import MLModel
 
@@ -11,7 +10,7 @@ from carla.models.api import MLModel
 def check_counterfactuals(
     mlmodel: MLModel,
     counterfactuals: Union[List, pd.DataFrame],
-    factuals_index: Index,
+    factuals_index: pd.Index,
     negative_label: int = 0,
 ) -> pd.DataFrame:
     """


### PR DESCRIPTION
Fixes #157 

This pull request fixes the ordering of counterfactuals generated by recourse generators which use `counterfactuals.check_counterfactuals`. Now the counterfactuals have the same indices as the factuals `DataFrame` passed to `get_counterfactuals` method.

Changes:
- added a `factuals_index` parameter to the `check_counterfactuals` method.
- passing `factuals.index` variable in recourse generators which use the method. 