### PR TITLE
Add FARE recourse method.

### DIFF
--- a/carla/recourse_methods/__init__.py
+++ b/carla/recourse_methods/__init__.py
@@ -5,6 +5,8 @@ from .catalog import (
     CCHVAE,
     CEM,
     CRUD,
+    EFARE,
+    FARE,
     FOCUS,
     ActionableRecourse,
     CausalRecourse,

--- a/carla/recourse_methods/catalog/__init__.py
+++ b/carla/recourse_methods/catalog/__init__.py
@@ -7,6 +7,7 @@ from .clue import Clue
 from .crud import CRUD
 from .dice import Dice
 from .face import Face
+from .fare import EFARE, FARE
 from .feature_tweak import FeatureTweak
 from .focus import FOCUS
 from .growing_spheres import GrowingSpheres

--- a/carla/recourse_methods/catalog/fare/__init__.py
+++ b/carla/recourse_methods/catalog/fare/__init__.py
@@ -1,0 +1,5 @@
+# flake8: noqa
+
+from .environment import MockEnv
+from .model import EFARE, FARE
+from .utils import fare_actions_factory

--- a/carla/recourse_methods/catalog/fare/environment.py
+++ b/carla/recourse_methods/catalog/fare/environment.py
@@ -1,0 +1,108 @@
+import pandas as pd
+import torch
+from recourse_fare.environment import Environment
+
+
+class MockEnv(Environment):
+    def __init__(
+        self, f, model, preprocessor, preprocessor_fare, programs_library, arguments
+    ):
+
+        self.preprocessor = preprocessor
+        self.preprocessor_fare = preprocessor_fare
+
+        self.prog_to_func = None  # We don't need this since we hacked the act method
+        self.prog_to_precondition = (
+            None  # We don't need this since we hacked the "can_be_called" method
+        )
+
+        self.prog_to_postcondition = self._intervene_postcondition
+
+        self.programs_library = programs_library
+        self.arguments = arguments
+
+        self.max_depth_dict = 12
+
+        # Call parent constructor
+        super().__init__(
+            f,
+            model,
+            self.prog_to_func,
+            self.prog_to_precondition,
+            self.prog_to_postcondition,
+            self.programs_library,
+            self.arguments,
+            self.max_depth_dict,
+        )
+
+    def can_be_called(self, program_index, args_index):
+        program = self.get_program_from_index(program_index)
+        args = self.complete_arguments[args_index]
+
+        mask_over_args = self.get_mask_over_args(program_index)
+        if mask_over_args[args_index] == 0:
+            return False
+
+        if program == "STOP":
+            return True
+
+        if self.features[program] == args:
+            return False
+
+        if isinstance(args, int) or isinstance(args, float):
+            return self.features[program] + args >= 0
+
+        return True
+
+    def act(self, primary_action, arguments=None):
+        assert self.has_been_reset, "Need to reset the environment before acting"
+        assert (
+            primary_action in self.primary_actions
+        ), "action {} is not defined".format(primary_action)
+
+        # The primary action is basically the feature we want to change.
+        # Therefore, based on the argument type, we change it accordingly
+
+        if primary_action == "STOP":
+            return self.get_observation()
+
+        if isinstance(arguments, int) or isinstance(arguments, float):
+            self.features[primary_action] += arguments
+        else:
+            self.features[primary_action] = arguments
+
+        return self.get_observation()
+
+    def get_state_str(self, state):
+        with torch.no_grad():
+            tmp = self.transform_user()[0]
+            val_out = self.classifier(tmp)
+        return state, torch.round(val_out).item()
+
+    def _placeholder_stop(self, args=None):
+        return True
+
+    def reset_to_state(self, state):
+        self.features = state.copy()
+
+    def get_stop_action_index(self):
+        return self.programs_library["STOP"]["index"]
+
+    # POSTCONDITIONS
+
+    def _intervene_postcondition(self, init_state, current_state):
+
+        obs = self.preprocessor.transform(pd.DataFrame.from_records([current_state]))
+        return self.model.predict(obs)[0] >= 0.5
+
+    def get_observation(self):
+
+        obs = self.preprocessor_fare.transform(
+            pd.DataFrame.from_records([self.features])
+        )
+        return torch.FloatTensor(obs.values[0])
+
+    def get_cost(self, program_index, args_index):
+
+        # Placeholder. Here we assume all actions have the same costs.
+        return 2

--- a/carla/recourse_methods/catalog/fare/model.py
+++ b/carla/recourse_methods/catalog/fare/model.py
@@ -1,0 +1,256 @@
+from typing import Any, Dict
+
+import pandas as pd
+from recourse_fare.models import EFARE as EFAREOriginal
+from recourse_fare.models import FARE as FAREOriginal
+
+from carla.models.api import MLModel
+from carla.recourse_methods.api import RecourseMethod
+from carla.recourse_methods.processing.counterfactuals import (
+    check_counterfactuals,
+    merge_default_parameters,
+)
+
+
+class FARE(RecourseMethod):
+    """
+    Implementation of FARE [1]_.
+
+    Parameters
+    ----------
+    mlmodel : carla.model.MLModel
+        Black-Box-Model
+    hyperparameters : dict
+        Dictionary containing hyperparameters. See notes below for its contents.
+
+    Methods
+    -------
+    fit:
+        Train the FARE model to generate counterfactual interventions.
+    save:
+        Save the trained model to disk.
+    load:
+        Load a trained FARE model from disk.
+    get_counterfactuals:
+        Generate counterfactual examples for given factuals.
+
+    Notes
+    -----
+    - Hyperparams
+        Hyperparameter contains important information for the recourse method to initialize.
+        Please make sure to pass all values as dict with the following keys.
+
+        * "environment_config": dict
+            Describe the environment, actions, preconditions and recourse conditions for the experiment.
+        * "mcts_config": dict
+            It contains the hyperparameters for the MCTS component.
+        * "policy_config": dict
+            It contains the hyperparameters (e.g., hidden size, embedding size, etc.) for the agent's policy.
+        * "batch_size": int
+            Size of the training batch when sampling from the replay buffer.
+        * "training_buffer_size": int
+            Size of the replay buffer.
+        * "validation_steps": int
+            After how many training steps we perform a validation round.
+
+    .. [1] De Toni, Giovanni, Bruno Lepri, and Andrea Passerini. "Synthesizing explainable counterfactual policies for algorithmic recourse with program synthesis." Machine Learning (2023): 1-21.
+    """
+
+    _DEFAULT_HYPERPARAMS = {
+        "environment_config": {
+            "class_name": "",
+            "additional_parameters": {
+                "preprocessor": None,
+                "preprocessor_fare": None,
+                "programs_library": None,
+                "arguments": None,
+            },
+        },
+        "mcts_config": {
+            "exploration": True,
+            "number_of_simulations": 10,
+            "dir_epsilon": 0.03,
+            "dir_noise": 0.3,
+            "level_closeness_coeff": 3.0,
+            "level_0_penalty": 1.0,
+            "qvalue_temperature": 1.0,
+            "temperature": 1.3,
+            "c_puct": 0.5,
+            "gamma": 0.97,
+        },
+        "policy_config": {
+            "observation_dim": 10,
+            "encoding_dim": 10,
+            "hidden_size": 40,
+        },
+        "batch_size": 10,
+        "training_buffer_size": 200,
+        "validation_steps": 10,
+    }
+
+    def __init__(self, mlmodel: MLModel, hyperparameters: Dict):
+
+        hyperparameters = merge_default_parameters(
+            hyperparameters, self._DEFAULT_HYPERPARAMS
+        )
+
+        environment_config = hyperparameters.get("environment_config")
+        mcts_config = hyperparameters.get("mcts_config")
+        policy_config = hyperparameters.get("policy_config")
+        batch_size = hyperparameters.get("batch_size")
+        training_buffer_size = hyperparameters.get("training_buffer_size")
+        validation_steps = hyperparameters.get("validation_steps")
+
+        self._fare_model = FAREOriginal(
+            model=mlmodel,
+            environment_config=environment_config,
+            policy_config=policy_config,
+            mcts_config=mcts_config,
+            batch_size=batch_size,
+            training_buffer_size=training_buffer_size,
+            validation_steps=validation_steps,
+        )
+        super().__init__(mlmodel)
+
+    @property
+    def fare_model(self):
+        return self._fare_model
+
+    def fit(
+        self,
+        X: Any,
+        max_iter: int = 1000,
+        verbose: bool = True,
+        tensorboard: Any = None,
+    ):
+        self.fare_model.fit(X, max_iter, verbose, tensorboard)
+
+    def save(self, save_model_path: str = "."):
+        self.fare_model.save(save_model_path)
+
+    def load(self, load_model_path: str = ".") -> None:
+        self.fare_model.load(load_model_path)
+
+    def get_counterfactuals(
+        self,
+        factuals: pd.DataFrame,
+        full_output: bool = False,
+        verbose: bool = True,
+        agent_only: bool = False,
+        mcts_only: bool = False,
+    ):
+
+        # Get the model's preprocessor
+        preprocessor = self.fare_model.environment_config.get(
+            "additional_parameters", {}
+        ).get("preprocessor", None)
+
+        assert (
+            preprocessor
+        ), "The FARE preprocessor is None. It is not possible to generate counterfactuals."
+
+        # Predict and get the counterfactuals
+        counterfactuals = self.fare_model.predict(
+            factuals,
+            full_output=full_output,
+            verbose=verbose,
+            agent_only=agent_only,
+            mcts_only=mcts_only,
+        )
+        counterfactuals = preprocessor.transform(counterfactuals)
+
+        # Check if the counterfactuals are okay
+        cf_df = check_counterfactuals(self._mlmodel, counterfactuals, factuals.index)
+        cf_df = self._mlmodel.get_ordered_features(cf_df)
+
+        return cf_df
+
+
+class EFARE(RecourseMethod):
+    """
+    Implementation of EFARE [1]_.
+
+    Parameters
+    ----------
+    hyperparameters : dict
+        Dictionary containing hyperparameters. See notes below for its contents.
+
+    Methods
+    -------
+    fit:
+        Train the EFARE model to generate counterfactual interventions (given a pretrained FARE model).
+    save:
+        Save the trained model to disk.
+    load:
+        Load a trained EFARE model from disk.
+    get_counterfactuals:
+        Generate counterfactual examples for given factuals.
+
+    Notes
+    -----
+    - Hyperparams
+        Hyperparameter contains important information for the recourse method to initialize.
+        Please make sure to pass all values as dict with the following keys.
+
+        * "fare_model": FARE
+            Pre-trained FARE model.
+        * "preprocessor": dict
+            Preprocessor for the EFARE model. It will be used to process the features for the decision trees.
+
+    .. [1] De Toni, Giovanni, Bruno Lepri, and Andrea Passerini. "Synthesizing explainable counterfactual policies for algorithmic recourse with program synthesis." Machine Learning (2023): 1-21.
+    """
+
+    _DEFAULT_HYPERPARAMS = {
+        "fare_model": None,
+        "preprocessor": None,
+        "preprocessor_efare": None,
+    }
+
+    def __init__(self, mlmodel: MLModel, hyperparameters: Dict):
+
+        hyperparameters = merge_default_parameters(
+            hyperparameters, self._DEFAULT_HYPERPARAMS
+        )
+
+        self.efare_model = EFAREOriginal(
+            fare_model=hyperparameters.get("fare_model"),
+            preprocessor=hyperparameters.get("preprocessor_efare"),
+        )
+
+        self.preprocessor_data = hyperparameters.get("preprocessor")
+
+        super().__init__(mlmodel)
+
+    def fit(
+        self,
+        X: Any,
+        verbose: bool = True,
+    ):
+        self.efare_model.fit(X, verbose)
+
+    def save(self, save_model_path: str = "."):
+        self.efare_model.save(save_model_path)
+
+    def load(self, load_model_path: str = ".") -> None:
+        self.efare_model.load(load_model_path)
+
+    def get_counterfactuals(
+        self, factuals: pd.DataFrame, full_output: bool = False, verbose: bool = True
+    ):
+
+        # Predict and get the counterfactuals
+        counterfactuals = self.efare_model.predict(
+            factuals, full_output=full_output, verbose=verbose
+        )
+
+        assert (
+            self.preprocessor_data
+        ), "The EFARE preprocessor is None. It is not possible to generate counterfactuals."
+
+        counterfactuals = self.preprocessor_data.transform(counterfactuals)
+
+        # Check if the counterfactuals are okay
+        cf_df = check_counterfactuals(self._mlmodel, counterfactuals, factuals.index)
+        cf_df = self._mlmodel.get_ordered_features(cf_df)
+
+        return cf_df

--- a/carla/recourse_methods/catalog/fare/utils.py
+++ b/carla/recourse_methods/catalog/fare/utils.py
@@ -1,0 +1,74 @@
+from typing import Any, Dict, List, Tuple
+
+import numpy as np
+import pandas as pd
+from pandas.api.types import is_categorical_dtype, is_numeric_dtype, is_object_dtype
+
+
+def fare_actions_factory(
+    df: pd.DataFrame, immutables: List[str], bins: int = 50
+) -> Tuple[Dict[Any, Any], Dict[Any, Any]]:
+    """Returns a set of actions/types needed by FARE by looking at the training set.
+    It works best with unprocessed features.
+
+    :param df: training set of the task
+    :type df: pd.DataFrame
+    :param immutables: columns we cannot modify
+    :type immutables: List[str]
+    :return: actions and types which can work with FARE
+    :type bins: int
+    :return: num parameter for the np.linspace method for numerical features
+    :rtype: Tuple[Dict[Any], Dict[Any]]
+    """
+
+    actions = {
+        "STOP": {"index": 0, "level": -1, "args": "NONE"},
+        "INTERVENE": {"index": 0, "level": 1, "args": "NONE"},
+    }
+
+    types = {"NONE": [0]}
+
+    # Check if there are binary variables
+    binary_features = df.columns[df.isin([0, 1]).all()]
+
+    # Set the action index
+    action_index = 1
+
+    # Build the corresponding types, one for each feature.
+    for c in df.columns:
+
+        # Skip the columns we cannot change
+        if c in immutables:
+            continue
+
+        # Add the corresponding action
+        actions[c] = {"index": action_index, "level": 0, "args": c}
+
+        if is_numeric_dtype(df[c]) and c not in binary_features:
+            min_value = df[c].min()
+            max_value = df[c].max()
+
+            types[c] = np.linspace(
+                0, np.sqrt(max_value - min_value), dtype=df[c].dtype, num=bins
+            )
+            types[c] += np.linspace(
+                -(np.sqrt(max_value - min_value)), 0, dtype=df[c].dtype, num=bins
+            )
+            types[c] = [value for value in types[c] if value != 0]  # Remove zeros
+            types[c] = list(set(types[c]))  # Remove potential harmful duplicates
+
+        elif (
+            is_categorical_dtype(df[c])
+            or is_object_dtype(df[c])
+            or c in binary_features
+        ):
+            types[c] = df[c].unique().tolist()
+        else:
+            print(f"Skipping over column {c}. It is not categorical not numeric")
+
+        action_index += 1
+
+    # Restore the INTERVENE action index
+    actions["INTERVENE"]["index"] = action_index
+
+    return actions, types

--- a/setup.py
+++ b/setup.py
@@ -52,5 +52,6 @@ setup(
         "keras==2.3.0",
         "xgboost==1.4.2",
         "causalgraphicalmodels==0.0.4",
+        "recourse-fare @ git+https://github.com/unitn-sml/recourse-fare",
     ],
 )


### PR DESCRIPTION
This PR is an initial attempt to add the following two novel recourse methods to the library, FARE and E-FARE [1]. Differently from other approaches, FARE couples a reinforcement learning agent and a discrete search procedure, MCTS, to efficiently discover counterfactual interventions. 

Currently, I have added FARE and a simple pytest to show its usage. Some class/function documentation is still missing, but I would like to start a discussion about what would be the best strategy to proceed.   

This PR also adds as a dependency the [sml-unitn/recourse-fare](https://github.com/unitn-sml/recourse-fare) repository where the original code is located (in order to avoid bloating CARLA with additional files). Obviously, this can be changed. 

Minor additions:

* Add suitable pytest with a MockEnv
* Add fare_actions_factory to quickly generate action sets
* Add sml-unitn/recourse-fare as a dependency

[1] De Toni, Giovanni, Bruno Lepri, and Andrea Passerini. "Synthesizing explainable counterfactual policies for algorithmic recourse with program synthesis." Machine Learning (2023): 1-21. [doi:10.1007/s10994-022-06293-7](https://link.springer.com/article/10.1007/s10994-022-06293-7)